### PR TITLE
Fix VPC route table output

### DIFF
--- a/example-local-vpc-module/main.tf
+++ b/example-local-vpc-module/main.tf
@@ -32,6 +32,6 @@ resource "local_file" "route_table" {
 Route Table for VPC: ${var.vpc_name}
 Routes:
 - Local: ${var.cidr_block}
-- Internet Gateway: ${var.enable_internet_gateway ? "0.0.0.0/0 -> igw-${var.vpc_name}" : "Not configured-test"}
+  - Internet Gateway: ${var.enable_internet_gateway ? "0.0.0.0/0 -> igw-${var.vpc_name}" : "Not configured"}
 EOF
 }


### PR DESCRIPTION
## Summary
- fix the not-configured text in the example VPC module

## Testing
- `terraform fmt -check -recursive` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853d9041a2c83308204f89c3bfb5b55